### PR TITLE
Fix template_root to point #{VagrantPlugins::GuestJunos.source_root}/…

### DIFF
--- a/lib/vagrant-junos.rb
+++ b/lib/vagrant-junos.rb
@@ -10,15 +10,15 @@ module VagrantPlugins
   # This communicates with the BSD shell of Junos,
   # which matches other Vagrant guest plugin behavior.
   module GuestJunos
+    # This returns the path to the source of this plugin.
+    #
+    # @return [Pathname]
+    def self.source_root
+      @source_root ||= Pathname.new(File.expand_path('../../', __FILE__))
+    end
+
     lib_path = Pathname.new(File.expand_path('../vagrant-junos', __FILE__))
     autoload :Action, lib_path.join('action')
     autoload :Errors, lib_path.join('errors')
-  end
-
-  # This returns the path to the source of this plugin.
-  #
-  # @return [Pathname]
-  def self.source_root
-    @source_root ||= Pathname.new(File.expand_path('../../', __FILE__))
   end
 end

--- a/lib/vagrant-junos/cap/change_host_name.rb
+++ b/lib/vagrant-junos/cap/change_host_name.rb
@@ -16,7 +16,7 @@ module VagrantPlugins
               # render template, based on Vagrantfile, and upload
               hostname_module = TemplateRenderer.render('guest/junos/hostname',
                                                         name: name,
-                                                        template_root: "#{Dir.home}/.vagrant.d/gems/gems/vagrant-junos-#{VagrantPlugins::GuestJunos::VERSION}/templates")
+                                                        template_root: "#{VagrantPlugins::GuestJunos.source_root}/templates")
               upload(machine, hostname_module, '/mfs/tmp/set_hostname')
 
               # set up us the Junos interfaces

--- a/lib/vagrant-junos/cap/configure_networks.rb
+++ b/lib/vagrant-junos/cap/configure_networks.rb
@@ -19,7 +19,7 @@ module VagrantPlugins
           # render template based on Vagrantfile, and upload
           network_module = TemplateRenderer.render('guest/junos/network',
                                                    options: networks,
-                                                   template_root: "#{Dir.home}/.vagrant.d/gems/gems/vagrant-junos-#{VagrantPlugins::GuestJunos::VERSION}/templates")
+                                                   template_root: "#{VagrantPlugins::GuestJunos.source_root}/templates")
           upload(machine, network_module, '/mfs/tmp/network')
           deploy(machine)
         end

--- a/lib/vagrant-junos/cap/insert_public_key.rb
+++ b/lib/vagrant-junos/cap/insert_public_key.rb
@@ -17,7 +17,7 @@ module VagrantPlugins
           # render public key junos conf template, based on Vagrantfile, and upload
           public_key_module = TemplateRenderer.render('guest/junos/public_key',
                                                       contents: contents,
-                                                      template_root: "#{Dir.home}/.vagrant.d/gems/gems/vagrant-junos-#{VagrantPlugins::GuestJunos::VERSION}/templates")
+                                                      template_root: "#{VagrantPlugins::GuestJunos.source_root}/templates")
           upload(machine, public_key_module, '/mfs/tmp/set_public_key')
 
           # set up us root's public key

--- a/lib/vagrant-junos/cap/remove_public_key.rb
+++ b/lib/vagrant-junos/cap/remove_public_key.rb
@@ -17,7 +17,7 @@ module VagrantPlugins
           # remove vagrant insecure public key (or anything called)
           public_key_module = TemplateRenderer.render('guest/junos/remove_public_key',
                                                       contents: contents,
-                                                      template_root: "#{Dir.home}/.vagrant.d/gems/gems/vagrant-junos-#{VagrantPlugins::GuestJunos::VERSION}/templates")
+                                                      template_root: "#{VagrantPlugins::GuestJunos.source_root}/templates")
           upload(machine, public_key_module, '/mfs/tmp/delete_public_key')
 
           # delete a public key for root


### PR DESCRIPTION
If you set the $VAGRANT_HOME value other than $HOME, vagrant-junos cannot find the template directory.