### PR TITLE
updated box image name which was no longer available.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Vagrant.require_plugin "vagrant-junos"
 ```
 Use bundler to execute Vagrant:
 ```
-$ bundle exec vagrant up juniper/ffp-12.1X46-D20.5
+$ bundle exec vagrant up juniper/ffp-12.1X47-D15.4-packetmode
 ```
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Install using standard Vagrant 1.7+ plugin installation methods.  The fastest wa
 $ vagrant plugin install vagrant-junos
 ...
 ... (create a Vagrant environment in a directory):
-$ vagrant init juniper/ffp-12.1X46-D20.5
+$ vagrant init juniper/ffp-12.1X47-D15.4-packetmode
 ...
 $ vagrant up
 ```


### PR DESCRIPTION
Could you please update the name of vagrant box image? 12.1X46-D20.5 seems not available now due to it has been deleted from external storage(S3?).